### PR TITLE
Fix stack size error in large paginations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.3.3-node
+      - image: cimg/ruby:2.7.5-node
     steps:
       - checkout
       # Restore bundle cache

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 *.o
 *.a
 mkmf.log
+
+.ruby-version

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,13 @@
+FROM watermarkchurch/workspace-full
+USER gitpod
+
+# https://www.gitpod.io/docs/languages/ruby
+RUN _ruby_version=ruby-2.7.5 \
+    && printf "rvm_gems_path=/home/gitpod/.rvm\n" > ~/.rvmrc \
+    && bash -lc "rvm reinstall ruby-${_ruby_version} && rvm use ruby-${_ruby_version} --default" \
+    && printf "rvm_gems_path=/workspace/.rvm" > ~/.rvmrc \
+    && printf '{ rvm use $(rvm current); } >/dev/null 2>&1\n' >> "$HOME/.bashrc.d/70-ruby"
+
+# https://www.gitpod.io/docs/languages/javascript#node-versions
+RUN bash -c 'VERSION="14" && source $HOME/.nvm/nvm.sh && nvm install $VERSION && nvm use $VERSION && nvm alias default $VERSION && npm install --global yarn'
+RUN echo "nvm use default &>/dev/null" >> ~/.bashrc.d/51-nvm-fix

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,30 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - init: |
+      bundle install
+    command: |
+      bundle exec guard -g autofix red_green_refactor
+
+vscode:
+  extensions:
+    - dbaeumer.vscode-eslint
+    - wingrunr21.vscode-ruby
+    - ms-azuretools.vscode-docker
+
+github:
+  prebuilds:
+    # enable for the default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: false
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: false
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: false
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: false
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: false

--- a/lib/wcc/api/rest_client/response.rb
+++ b/lib/wcc/api/rest_client/response.rb
@@ -64,11 +64,11 @@ module WCC::API
       def next_page
         return unless next_page?
 
-        @next_page ||= @client.get(
+        next_page ||= @client.get(
           @request[:url],
           (@request[:query] || {}).merge(next_page_query)
         )
-        @next_page.assert_ok!
+        next_page.assert_ok!
       end
 
       def assert_ok!

--- a/lib/wcc/api/rest_client/response.rb
+++ b/lib/wcc/api/rest_client/response.rb
@@ -129,7 +129,7 @@ module WCC::API
       include Enumerable
   
       def initialize(initial_page)
-        raise ArgumentError, 'Must provide initial page' unless initial_page.present?
+        raise ArgumentError, 'Must provide initial page' unless initial_page
   
         @initial_page = initial_page
       end

--- a/lib/wcc/api/rest_client/response.rb
+++ b/lib/wcc/api/rest_client/response.rb
@@ -81,16 +81,7 @@ module WCC::API
       def each_page(&block)
         raise ArgumentError, 'Not a collection response' unless collection_response?
 
-        ret =
-          Enumerator.new do |y|
-            y << self
-
-            if next_page?
-              next_page.each_page.each do |page|
-                y << page
-              end
-            end
-          end
+        ret = PaginatingEnumerable.new(self)
 
         if block_given?
           ret.map(&block)
@@ -131,6 +122,26 @@ module WCC::API
 
       def page_items
         body['items']
+      end
+    end
+
+    class PaginatingEnumerable
+      include Enumerable
+  
+      def initialize(initial_page)
+        raise ArgumentError, 'Must provide initial page' unless initial_page.present?
+  
+        @initial_page = initial_page
+      end
+  
+      def each
+        page = @initial_page
+        yield page
+  
+        while page.next_page?
+          page = page.next_page
+          yield page
+        end
       end
     end
   end

--- a/wcc-api.gemspec
+++ b/wcc-api.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'wcc-base'
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'dotenv', '~> 0.10.0'
   spec.add_development_dependency 'faraday', '~> 0.9'
   spec.add_development_dependency 'guard', '~> 2.15'


### PR DESCRIPTION
Applying the same solution as https://github.com/watermarkchurch/wcc-contentful/pull/257, we solve two memory-related errors at once:
1. https://github.com/watermarkchurch/paper-signs/issues/2819
    the stack size was too large because each page yields back through the previous page.  Once we get over a couple hundred pages (which we have now achieved on the Media API), the stack gets too large and crashes the process.
3. https://github.com/watermarkchurch/paper-signs/issues/2766
    Each page was keeping a reference to the next page in the `@next_page` memoized variable.  This linked list of pages would baloon in memory, because each page has a reference to the raw JSON string as well as the parsed JSON items.  In the case of Contentful, it would keep all includes as well, until we finally are done paginating and garbage collect the whole thing. Now, intermediate pages can be garbage-collected while we fetch future pages.